### PR TITLE
Fix escape char problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
             "title": "Terminal API: Send Text"
         }, {
             "command": "terminalTest.sendTextNoNewLine",
-            "title": "Terminal API: Send Text (no implied \n)"
+            "title": "Terminal API: Send Text (no implied \\n)"
         }, {
             "command": "terminalTest.dispose",
             "title": "Terminal API: Dispose"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,13 +24,13 @@ export function activate(context: vscode.ExtensionContext) {
         if (terminalStack.length === 0) {
             vscode.window.showErrorMessage('No active terminals');
         }
-        getLatestTerminal().sendText("echo \"Hello world!\"");
+        getLatestTerminal().sendText("echo 'Hello world!'");
     }));
     context.subscriptions.push(vscode.commands.registerCommand('terminalTest.sendTextNoNewLine', () => {
         if (terminalStack.length === 0) {
             vscode.window.showErrorMessage('No active terminals');
         }
-        getLatestTerminal().sendText("echo \"Hello world!\"", false);
+        getLatestTerminal().sendText("echo 'Hello world!'", false);
     }));
     context.subscriptions.push(vscode.commands.registerCommand('terminalTest.dispose', () => {
         if (terminalStack.length === 0) {


### PR DESCRIPTION
`echo "Hello world!"` will leave `dquote>` in next line, as `!` in double quotes is interpreted as shell expansion.

Also need to show literal `\n` in the Command Palette.
